### PR TITLE
Fix: videos are not auto playing

### DIFF
--- a/src/components/profile/ProfileCollection.js
+++ b/src/components/profile/ProfileCollection.js
@@ -281,7 +281,7 @@ export function ProfileCollection({ profileData }) {
 														<Form.Check.Label>
 															<Card id={"card" + object} className="create-album-card p-3">
 																{nftData.contentType === "video" ?
-																	<video className="" alt={"Picture of " + nftData.name} loop="" playsInline="">
+																	<video className="" alt={"Picture of " + nftData.name} loop="" playsInline="" autoPlay muted>
 																		<source src={imgUrl + "#t=0.1"} type="video/mp4"></source>
 																		Sorry this video is not supported by your browser
 																	</video>
@@ -401,7 +401,7 @@ export function ProfileCollection({ profileData }) {
 											}
 											<a href={url} target="_blank" rel="noreferrer">
 												{nftData.contentType === "video" ?
-													<video className="collection-img p-3" alt={"Picture of " + nftData.name} loop="" playsInline="">
+													<video className="collection-img p-3" alt={"Picture of " + nftData.name} loop="" playsInline="" autoPlay muted>
 														<source src={imgUrl + "#t=0.1"} type="video/mp4"></source>
 														Sorry this video is not supported by your browser
 													</video>
@@ -462,7 +462,7 @@ export function ProfileCollection({ profileData }) {
 									}
 									<a href={url} target="_blank" rel="noreferrer">
 										{nftData.contentType === "video" ?
-											<video className="collection-img p-3" alt={"Picture of " + nftData.name} loop="" playsInline="">
+											<video className="collection-img p-3" alt={"Picture of " + nftData.name} loop="" playsInline="" autoPlay muted>
 												<source src={imgUrl + "#t=0.1"} type="video/mp4"></source>
 												Sorry this video is not supported by your browser
 											</video>

--- a/src/components/profile/ProfileCollection.js
+++ b/src/components/profile/ProfileCollection.js
@@ -281,7 +281,13 @@ export function ProfileCollection({ profileData }) {
 														<Form.Check.Label>
 															<Card id={"card" + object} className="create-album-card p-3">
 																{nftData.contentType === "video" ?
-																	<video className="" alt={"Picture of " + nftData.name} loop="" playsInline="" autoPlay muted>
+																	<video
+																		className=""
+																		alt={"Picture of " + nftData.name}
+																		loop="" playsInline=""
+																		onMouseOver={event => event.target.play()}
+																		onMouseOut={event => event.target.pause()}
+																	>
 																		<source src={imgUrl + "#t=0.1"} type="video/mp4"></source>
 																		Sorry this video is not supported by your browser
 																	</video>
@@ -401,7 +407,13 @@ export function ProfileCollection({ profileData }) {
 											}
 											<a href={url} target="_blank" rel="noreferrer">
 												{nftData.contentType === "video" ?
-													<video className="collection-img p-3" alt={"Picture of " + nftData.name} loop="" playsInline="" autoPlay muted>
+													<video
+														className="collection-img p-3"
+														alt={"Picture of " + nftData.name}
+														loop="" playsInline=""
+														onMouseOver={event => event.target.play()}
+														onMouseOut={event => event.target.pause()}
+													>
 														<source src={imgUrl + "#t=0.1"} type="video/mp4"></source>
 														Sorry this video is not supported by your browser
 													</video>
@@ -462,7 +474,13 @@ export function ProfileCollection({ profileData }) {
 									}
 									<a href={url} target="_blank" rel="noreferrer">
 										{nftData.contentType === "video" ?
-											<video className="collection-img p-3" alt={"Picture of " + nftData.name} loop="" playsInline="" autoPlay muted>
+											<video
+												className="collection-img p-3"
+												alt={"Picture of " + nftData.name}
+												loop="" playsInline=""
+												onMouseOver={event => event.target.play()}
+												onMouseOut={event => event.target.pause()}
+											>
 												<source src={imgUrl + "#t=0.1"} type="video/mp4"></source>
 												Sorry this video is not supported by your browser
 											</video>


### PR DESCRIPTION
Example of a video NFT not autoplaying https://find.xyz/laguitte/collection/OneFootballCollectible
Ref:
- https://developer.chrome.com/blog/autoplay/
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video

I could reproduce the issues in Chrome, Brave (chromium) and Safari.

When I spin un the dev env I can successfully see the videos autoplaying
![image](https://user-images.githubusercontent.com/7823843/149812311-286fbe55-c3da-4514-b38c-f72c2a983946.png)
although you will notice that the `muted` is gone, but that's a known issue of React apparently https://stackoverflow.com/questions/61510160/why-muted-attribute-on-video-tag-is-ignored-in-react